### PR TITLE
Add small fixes for demo yamls.

### DIFF
--- a/demo/03-multistep.yaml
+++ b/demo/03-multistep.yaml
@@ -14,7 +14,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         echo Preparing greeting
-        echo Hello $(params.person) > ~/hello.txt
+        echo Hello $(params.person) > /tekton/home/hello.txt
         sleep 2
         echo Done!
     - name: say-hello

--- a/demo/07-pipelineresource.yaml
+++ b/demo/07-pipelineresource.yaml
@@ -11,6 +11,7 @@ spec:
   steps:
     - name: count
       image: registry.access.redhat.com/ubi8/ubi
+      workingDir: /workspace
       command:
         - /bin/bash
       args: ['-c', 'echo $(find ./code -type f | wc -l) files in repo']

--- a/demo/08-realworld.yaml
+++ b/demo/08-realworld.yaml
@@ -19,11 +19,13 @@ spec:
   steps:
     - name: npm-install
       image: node:14
+      workingDir: /workspace
       command:
         - /bin/bash
       args: ['-c', 'cd repo/$(params.pathContext) && npm install']
     - name: npm-lint
       image: node:14
+      workingDir: /workspace
       command:
         - /bin/bash
       args: ['-c', 'cd repo/$(params.pathContext) && npm $(params.action)']
@@ -95,6 +97,9 @@ spec:
     - name: image-name
       type: string
       description: Name of the image to produce (will be user/image-name)
+    - name: registry
+      type: string
+      default: "docker.io"
   resources:
     - name: git-repo
       type: git
@@ -131,6 +136,8 @@ spec:
           value: $(params.pass)
         - name: image-name
           value: $(params.image-name)
+        - name: registry
+          value: $(params.registry)
       taskRef:
         name: s2i-nodejs
       resources:


### PR DESCRIPTION
###
Fix some demo yamls, because some of them failed for my tekton installation:

```bash
$ tkn version
Client version: 0.21.0
Pipeline version: v0.31.0
$ minikube version
minikube version: v1.23.2
commit: 0a0ad764652082477c00d51d2475284b5d39ceed
$ sw_vers
ProductName:	macOS
ProductVersion:	12.1
BuildVersion:	21C52
```

Add image `registry` parameter for realworld tekton example to use another registry (quay.io for example).

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>